### PR TITLE
Potential fix for code scanning alert no. 24: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,4 +1,6 @@
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/benpate/rosetta/security/code-scanning/24](https://github.com/benpate/rosetta/security/code-scanning/24)

To remediate this issue, we should add an explicit `permissions` block at the most appropriate scope in the workflow YAML file. Since the workflow contains only one job ("build"), and there is no indication that different jobs with differing permissions are planned, adding the `permissions` block at the workflow (root) level is the most straightforward solution. The minimal starting point, as recommended by CodeQL and GitHub, is `permissions: contents: read`. However, reviewing the steps: 

- `actions/checkout@v4` only requires `contents: read`.
- `codecov/codecov-action@v5`, `golangci/golangci-lint-action@v8`, and `qbaware/nilaway-action@v0` do not require write permissions unless explicitly uploading or modifying repository content or issues, which we do not see here.

Thus, adding `permissions: contents: read` at the root level (just below the `name:` declaration, above `on:`) adheres to principle of least privilege, and resolves the warning.

Only `.github/workflows/go.yml` is affected, and the fix consists of adding the following lines:

```yml
permissions:
  contents: read
```

as lines 2.1–2.2, just after the `name:` line and before `on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
